### PR TITLE
Add Wonde API aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Wonde API Aggregator
+
+This repository contains a minimal .NET 7 web API which integrates with the [Wonde API](https://docs.wonde.com/docs/api/sync/).
+
+The service exposes an endpoint `/aggregate` which performs the following actions:
+
+1. Requests staff information including roles and classes.
+2. For every staff member, requests the classes they teach including students.
+3. Requests all classes that have students.
+4. For each student discovered, requests details including attendance summaries, results and behaviours.
+5. Aggregates all the responses and writes them to `aggregated_results.json` in the application directory.
+
+The project files reside in the `WondeApiAggregator` directory.
+
+## Building and Running
+
+This project targets **.NET 7**. Use the .NET 7 SDK to build and run:
+
+```bash
+cd WondeApiAggregator
+# Build
+ dotnet build
+# Run
+ dotnet run
+```
+
+Once running, navigate to `http://localhost:5000/aggregate` to trigger the aggregation process. The endpoint returns the aggregated JSON and also stores it on disk.
+
+> **Note**: The token used for the API requests is hardcoded in `WondeService.cs`. Replace it with a valid token if necessary.

--- a/WondeApiAggregator/Program.cs
+++ b/WondeApiAggregator/Program.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using WondeApiAggregator.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHttpClient<WondeService>();
+
+var app = builder.Build();
+
+app.MapGet("/aggregate", async (WondeService service) =>
+{
+    var result = await service.AggregateAsync();
+    return Results.Json(result);
+});
+
+app.Run();

--- a/WondeApiAggregator/Services/WondeService.cs
+++ b/WondeApiAggregator/Services/WondeService.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Net.Http.Headers;
+
+namespace WondeApiAggregator.Services
+{
+    public class WondeService
+    {
+        private readonly HttpClient _client;
+
+        private const string BaseUrl = "https://api.wonde.com/v1.0";
+        private const string Token = "779c8206c48425b2e48821aaf4e205cc561446db";
+
+        public WondeService(HttpClient client)
+        {
+            _client = client;
+            _client.BaseAddress = new Uri(BaseUrl);
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        }
+
+        public async Task<JsonObject> AggregateAsync()
+        {
+            var staff = await GetJsonAsync("/staff?include=roles,classes");
+            var staffIds = staff?["data"]?.AsArray().Select(s => s?["id"]?.GetValue<string>()!)?.ToList() ?? new List<string>();
+
+            var classesByTeacher = new JsonArray();
+            foreach (var id in staffIds)
+            {
+                var classes = await GetJsonAsync($"/classes?teachers={id}&include=students");
+                if (classes != null)
+                    classesByTeacher.Add(classes);
+            }
+
+            var classesWithStudents = await GetJsonAsync("/classes?include=students&has_students=true");
+
+            var studentIds = classesWithStudents?["data"]?
+                .AsArray()
+                .SelectMany(c => c?["students"]?.AsArray().Select(s => s?["id"]?.GetValue<string>()!))
+                .Distinct()
+                .ToList() ?? new List<string>();
+
+            var students = new JsonArray();
+            foreach (var sid in studentIds)
+            {
+                var student = await GetJsonAsync($"/students/{sid}?include=attendance_summary,results,results.aspect,behaviours");
+                if (student != null)
+                    students.Add(student);
+            }
+
+            var aggregated = new JsonObject
+            {
+                ["staff"] = staff,
+                ["classesByTeacher"] = classesByTeacher,
+                ["classesWithStudents"] = classesWithStudents,
+                ["students"] = students
+            };
+
+            await File.WriteAllTextAsync("aggregated_results.json", aggregated.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+
+            return aggregated;
+        }
+
+        private async Task<JsonObject?> GetJsonAsync(string path)
+        {
+            using var resp = await _client.GetAsync(path);
+            resp.EnsureSuccessStatusCode();
+            var stream = await resp.Content.ReadAsStreamAsync();
+            var node = await JsonNode.ParseAsync(stream);
+            return node as JsonObject;
+        }
+    }
+}

--- a/WondeApiAggregator/WondeApiAggregator.csproj
+++ b/WondeApiAggregator/WondeApiAggregator.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- create minimal .NET 7 web API
- implement aggregator service hitting multiple Wonde endpoints and writing `aggregated_results.json`
- document build and run instructions

## Testing
- `dotnet build` *(fails: `dotnet` not found)*